### PR TITLE
Add unit tests for validation functions

### DIFF
--- a/AddressBook_Cpp.sln
+++ b/AddressBook_Cpp.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.11.35327.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AddressBook_Cpp", "AddressBook_Cpp\AddressBook_Cpp.vcxproj", "{A746B138-E871-4590-8D0E-0DC3CC5797D0}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AddressBook_Test", "AddressBook_Test\AddressBook_Test.vcxproj", "{F27C0397-C182-43F4-B1D3-B9B529E18C5D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -21,6 +23,14 @@ Global
 		{A746B138-E871-4590-8D0E-0DC3CC5797D0}.Release|x64.Build.0 = Release|x64
 		{A746B138-E871-4590-8D0E-0DC3CC5797D0}.Release|x86.ActiveCfg = Release|Win32
 		{A746B138-E871-4590-8D0E-0DC3CC5797D0}.Release|x86.Build.0 = Release|Win32
+		{F27C0397-C182-43F4-B1D3-B9B529E18C5D}.Debug|x64.ActiveCfg = Debug|x64
+		{F27C0397-C182-43F4-B1D3-B9B529E18C5D}.Debug|x64.Build.0 = Debug|x64
+		{F27C0397-C182-43F4-B1D3-B9B529E18C5D}.Debug|x86.ActiveCfg = Debug|Win32
+		{F27C0397-C182-43F4-B1D3-B9B529E18C5D}.Debug|x86.Build.0 = Debug|Win32
+		{F27C0397-C182-43F4-B1D3-B9B529E18C5D}.Release|x64.ActiveCfg = Release|x64
+		{F27C0397-C182-43F4-B1D3-B9B529E18C5D}.Release|x64.Build.0 = Release|x64
+		{F27C0397-C182-43F4-B1D3-B9B529E18C5D}.Release|x86.ActiveCfg = Release|Win32
+		{F27C0397-C182-43F4-B1D3-B9B529E18C5D}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AddressBook_Cpp/AddressBook_Cpp.vcxproj
+++ b/AddressBook_Cpp/AddressBook_Cpp.vcxproj
@@ -40,7 +40,7 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
@@ -130,11 +130,13 @@
   <ItemGroup>
     <ClInclude Include="include\common.h" />
     <ClInclude Include="include\contact.h" />
+    <ClInclude Include="tests\test.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
     <ClCompile Include="src\common.cpp" />
     <ClCompile Include="src\contact.cpp" />
+    <ClCompile Include="tests\test.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/AddressBook_Cpp/src/common.cpp
+++ b/AddressBook_Cpp/src/common.cpp
@@ -3,6 +3,9 @@
 
 bool Validator::IsAllDigit(const std::string& str)
 {
+	if (str.empty())
+		return false;
+
 	for (char c : str)
 	{
 		if (!std::isdigit(static_cast<unsigned char>(c)))
@@ -13,6 +16,9 @@ bool Validator::IsAllDigit(const std::string& str)
 
 bool Validator::IsAllAlpha(const std::string& str)
 {
+	if (str.empty())
+		return false;
+
 	for (char c : str)
 	{
 		if (!std::isalpha(static_cast<unsigned char>(c)))
@@ -23,9 +29,6 @@ bool Validator::IsAllAlpha(const std::string& str)
 
 bool Validator::IsPhoneFormat(const std::string& str)
 {
-	if (str.empty())
-		return false;
-
 	if (str.length() != 13)
 		return false;
 

--- a/AddressBook_Cpp/tests/test.h
+++ b/AddressBook_Cpp/tests/test.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/AddressBook_Test/AddressBook_Test.vcxproj
+++ b/AddressBook_Test/AddressBook_Test.vcxproj
@@ -1,0 +1,128 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{f27c0397-c182-43f4-b1d3-b9b529e18c5d}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>X64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="test.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AddressBook_Cpp\AddressBook_Cpp.vcxproj">
+      <Project>{a746b138-e871-4590-8d0e-0dc3cc5797d0}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1.7\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+  </Target>
+</Project>

--- a/AddressBook_Test/AddressBook_Test.vcxproj
+++ b/AddressBook_Test/AddressBook_Test.vcxproj
@@ -57,10 +57,12 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/AddressBook_Test/packages.config
+++ b/AddressBook_Test/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.7" targetFramework="native" />
+</packages>

--- a/AddressBook_Test/pch.cpp
+++ b/AddressBook_Test/pch.cpp
@@ -1,0 +1,5 @@
+//
+// pch.cpp
+//
+
+#include "pch.h"

--- a/AddressBook_Test/pch.h
+++ b/AddressBook_Test/pch.h
@@ -1,0 +1,7 @@
+//
+// pch.h
+//
+
+#pragma once
+
+#include "gtest/gtest.h"

--- a/AddressBook_Test/test.cpp
+++ b/AddressBook_Test/test.cpp
@@ -1,0 +1,6 @@
+#include "pch.h"
+
+TEST(TestCaseName, TestName) {
+  EXPECT_EQ(1, 1);
+  EXPECT_TRUE(true);
+}

--- a/AddressBook_Test/test.cpp
+++ b/AddressBook_Test/test.cpp
@@ -1,6 +1,10 @@
 #include "pch.h"
+#include <gtest/gtest.h>
+#include "..\AddressBook_Cpp\include\common.h"
 
-TEST(TestCaseName, TestName) {
-  EXPECT_EQ(1, 1);
-  EXPECT_TRUE(true);
+TEST(ValidatorTest, TestIsAllDigit)
+{
+	EXPECT_TRUE(Validator::IsAllDigit("12345"));
+	EXPECT_FALSE(Validator::IsAllDigit("123a5"));
+	EXPECT_FALSE(Validator::IsAllDigit(""));
 }

--- a/AddressBook_Test/test.cpp
+++ b/AddressBook_Test/test.cpp
@@ -4,7 +4,24 @@
 
 TEST(ValidatorTest, TestIsAllDigit)
 {
-	EXPECT_TRUE(Validator::IsAllDigit("12345"));
-	EXPECT_FALSE(Validator::IsAllDigit("123a5"));
-	EXPECT_FALSE(Validator::IsAllDigit(""));
+	EXPECT_TRUE(Validator::IsAllDigit("12345"));	// Pass
+	EXPECT_FALSE(Validator::IsAllDigit("123a5"));	// Fail	
+	EXPECT_FALSE(Validator::IsAllDigit("1@345"));	// Fail	
+	EXPECT_FALSE(Validator::IsAllDigit(""));		// Fail
+}
+
+TEST(ValidatorTest, TestIsAllAlpha)
+{
+	EXPECT_TRUE(Validator::IsAllAlpha("abcDEF"));	// Pass
+	EXPECT_FALSE(Validator::IsAllAlpha("abc123"));	// Fail
+	EXPECT_FALSE(Validator::IsAllAlpha("abc DEF"));	// Fail
+	EXPECT_FALSE(Validator::IsAllAlpha(""));	// Fail
+}
+
+TEST(ValidatorTest, TestIsPhoneFormat)
+{
+	EXPECT_TRUE(Validator::IsPhoneFormat("000-0000-0000"));		// Pass
+	EXPECT_FALSE(Validator::IsPhoneFormat("0000-0000-0000"));	// Fail
+	EXPECT_FALSE(Validator::IsPhoneFormat("000-aaaa-0000"));	// Fail
+	EXPECT_FALSE(Validator::IsPhoneFormat(""));	// Fail
 }


### PR DESCRIPTION
This commit adds unit tests to validate the functionality of the Validator class methods:
- `IsAllDigit`: Checks if a string contains only digits
- `IsAllAlpha`: Checks if a string contains only alphabetic characters
- `IsPhoneFormat`: Validates if a string matches the phone number format (xxx-xxxx-xxxx)