### PR TITLE
Add JSON serialization and deserialization for Contact class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Ignore files in the tests folder that contain 'test' in the filename
+/AddressBook_Cpp/tests/*test*

--- a/AddressBook_Cpp/include/Contact.h
+++ b/AddressBook_Cpp/include/Contact.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "json.hpp"
+
 class Contact {
 private:
 	int age;
@@ -21,4 +23,8 @@ public:
 	bool SetAge(const int newAge);
 	bool SetName(const std::string& newName);
 	bool SetPhone(const std::string& newPhone);
+
+	// Serialization
+	friend void to_json(nlohmann::json& j, const Contact& c);
+	friend void from_json(const nlohmann::json& j, Contact& c);
 };

--- a/AddressBook_Cpp/main.cpp
+++ b/AddressBook_Cpp/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <Windows.h>
 #include "common.h"
 #include "contact.h"
 #include "contact_store.h"
@@ -6,14 +7,96 @@
 
 int main(void)
 {
+	const wchar_t* filePath = L".\\tests\\test.json";
+
 	Contact contact(10, "Alice", "010-0000-1111");
 
-	nlohmann::json j;
+	nlohmann::json j = contact;
 
-	j["age"] = contact.GetAge();
-	j["name"] = contact.GetName();
-	j["phone"] = contact.GetPhone();
+	// Serialize the contact to JSON
+	HANDLE hFile = CreateFile(
+		filePath,
+		GENERIC_WRITE,
+		0,
+		NULL,
+		CREATE_ALWAYS,
+		FILE_ATTRIBUTE_NORMAL,
+		NULL
+	);
+	if (hFile == INVALID_HANDLE_VALUE)
+	{
+		std::cerr << "Failed to create file" << std::endl;
+		return 1;
+	}
 
-	std::cout << "Serialized JSON: " << j.dump(4) << std::endl;
+	std::string jsonStr = j.dump();
+
+	DWORD dwWritten = 0;
+	BOOL bResult = FALSE;
+
+	bResult = WriteFile(hFile, jsonStr.c_str(), (DWORD)jsonStr.size(), &dwWritten, NULL);
+	if (!bResult)
+	{
+		std::cerr << "Failed to write to file" << std::endl;
+		CloseHandle(hFile);
+		return 1;
+	}
+
+	CloseHandle(hFile);
+
+	std::cout << "Contact serialized to JSON and written to file successfully." << std::endl;
+
+	// Deserialize the contact from JSON
+	hFile = CreateFile(
+		filePath,
+		GENERIC_READ,
+		0,
+		NULL,
+		OPEN_EXISTING,
+		FILE_ATTRIBUTE_NORMAL,
+		NULL
+	);
+	if (hFile == INVALID_HANDLE_VALUE)
+	{
+		std::cerr << "Failed to open file" << std::endl;
+		return 1;
+	}
+
+	DWORD dwFileSize = GetFileSize(hFile, NULL);
+	if (dwFileSize == INVALID_FILE_SIZE)
+	{
+		std::cerr << "Failed to get file size" << std::endl;
+		CloseHandle(hFile);
+		return 1;
+	}
+
+	char* buffer = new char[dwFileSize + 1];
+	DWORD dwReadSize = 0;
+	bResult = FALSE;
+
+	bResult = ReadFile(hFile, buffer, dwFileSize, &dwReadSize, NULL);
+	if (!bResult || dwReadSize == 0)
+	{
+		std::cerr << "Failed to read from file" << std::endl;
+		delete[] buffer;
+		CloseHandle(hFile);
+		return 1;
+	}
+
+	buffer[dwReadSize] = '\0';
+
+	try {
+		nlohmann::json j = nlohmann::json::parse(buffer);
+		std::cout << "Read JSON: " << j.dump(4) << std::endl;
+	}
+	catch (const nlohmann::json::parse_error& e) {
+		std::cerr << "Failed to parse JSON: " << e.what() << std::endl;
+		delete[] buffer;
+		CloseHandle(hFile);
+		return 1;
+	}
+
+	delete[] buffer;
+	CloseHandle(hFile);
 	return 0;
 }

--- a/AddressBook_Cpp/src/Contact.cpp
+++ b/AddressBook_Cpp/src/Contact.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include "common.h"
 #include "contact.h"
+#include "json.hpp"
 
 Contact::Contact(const int age, const std::string& name, const std::string& phone)
 	: age(age), name(name), phone(phone) {}
@@ -42,4 +43,20 @@ bool Contact::SetPhone(const std::string& newPhone)
 		return false;
 	phone = newPhone;
 	return true;
+}
+
+void to_json(nlohmann::json& j, const Contact& c)
+{
+	j = nlohmann::json{
+		{"age", c.age},
+		{"name", c.name},
+		{"phone", c.phone}
+	};
+}
+
+void from_json(const nlohmann::json& j, Contact& c)
+{
+	j.at("age").get_to(c.age);
+	j.at("name").get_to(c.name);
+	j.at("phone").get_to(c.phone);
 }


### PR DESCRIPTION
- Implemented `to_json` and `from_json` functions as friend functions of the `Contact` class.
- Updated the `main` function to demonstrate serializing and deserializing `Contact` objects to/from JSON files using Windows API for file I/O.
- Also, updated the `.gitignore` file to exclude `test` files in the `tests` folder.