### PR TITLE
feat(FileManager): Implement LoadFromFile function for loading records

### DIFF
--- a/AddressBook_Cpp/include/file_manager.h
+++ b/AddressBook_Cpp/include/file_manager.h
@@ -23,6 +23,8 @@ public:
 
 	static IORESULT SaveToFile(const std::wstring& fileName, ContactStore& store);
 
+	static IORESULT LoadFromFile(const std::wstring& fileName, ContactStore& store);
+
 	static IORESULT LoadRecordFromFileByPhone(
 		const std::wstring& fileName,
 		const std::string& phone,

--- a/AddressBook_Cpp/main.cpp
+++ b/AddressBook_Cpp/main.cpp
@@ -12,14 +12,15 @@ int main(void)
 {
 	//CreateDirectory(L".\\tests", NULL);
 	
-	UIEventManager::Option option = UIManager::PrintMenu();
-	while (option != UIEventManager::Option::MENU_EXIT)
-	{
-		UIEventManager::menuFunctions[option]();
-		std::getchar();
+	ContactStore store;
+	FileManager::LoadFromFile(L"tests\\test.dat", store);
 
-		option = UIManager::PrintMenu();
-	}
+	store.forEach([](const Contact& contact) {
+		std::cout <<
+			"Age: " << contact.GetAge() << '\n' <<
+			"Name: " << contact.GetName() << '\n' <<
+			"Phone: " << contact.GetPhone() << std::endl;
+		});
 	
 	return 0;
 }


### PR DESCRIPTION
from file

- Adds `LoadFromFile` function to read contact records from a specified file
- Uses `ReadFile` to read the file in chunks and deserialize the contact data
- Handles various error conditions including empty file, invalid data size, and file read errors
- Inserts deserialized contacts into the `ContactStore` and cleans up after processing
- Returns appropriate IORESULT codes based on the outcome