### PR TITLE
fix(FileManager): Correct targetEnd pointer calculation in

### DIFF
--- a/AddressBook_Cpp/src/file_manager.cpp
+++ b/AddressBook_Cpp/src/file_manager.cpp
@@ -268,7 +268,7 @@ IORESULT FileManager::DeleteRecordFromFileByPhone(
 					return IO_FILE_WRITE_ERROR;
 				}
 
-				char* targetEnd = phonePos + Contact::GetContactSize();
+				char* targetEnd = targetPos + Contact::GetContactSize();
 				DWORD afterSize = dwRead - beforeSize - Contact::GetContactSize();
 				bResult = WriteFile(hFileTemp, targetEnd, afterSize, &dwWritten, NULL);
 				if (!bResult || afterSize != dwWritten)


### PR DESCRIPTION
DeleteRecordFromFileByPhone

- Fixed bug where `targetEnd` pointer was incorrectly caculated using `phonePos` instead of `targetPos`
- Updated `targetEnd` to properly reference the position after the contact data to handle file write operation correctly
- Ensured that data is written after the correct contact information in the file